### PR TITLE
store only server base uri in env variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 REACT_APP_CLIENT_ID=abcdefghijk
 REACT_APP_REDIRECT_URI=http://localhost:8000/login
 REACT_APP_GITHUB_SERVER=http://localhost:8000/githubAuth
-REACT_APP_SERVER_URI=http://localhost:8000/createservice
-REACT_APP_LIST_URI=http://localhost:8000/listcluster
+REACT_APP_SERVER_URI=http://localhost:8000/
+REACT_APP_URL=https://github.com/login/oauth/authorize?client_id=abcdefghijk&redirect_uri=http://localhost:3000/login

--- a/src/api/createService.js
+++ b/src/api/createService.js
@@ -10,7 +10,7 @@ export const handleOk = async (name, database, version, username, password) => {
   }
   try {
     var response = await axios.post(
-      `${process.env.REACT_APP_SERVER_URI}`,
+      `${process.env.REACT_APP_SERVER_URI}/createservice`,
       {
         UserID: JSON.parse(localStorage.getItem("details")).login,
         Db: {

--- a/src/api/listCluster.js
+++ b/src/api/listCluster.js
@@ -3,7 +3,7 @@ import { createNotification } from "../components/notifications/notify";
 
 export const getClusters = async () => {
   try {
-    var response = await axios.get(process.env.REACT_APP_LIST_URI, {
+    let response = await axios.get(`${process.env.REACT_APP_SERVER_URI}/listcluster`, {
       headers: {
         Authorization: `Bearer ${
           JSON.parse(localStorage.getItem("details")).jwttoken


### PR DESCRIPTION
At the moment we keep specific endpoints in the `.env` variable (e.g listCluster and createService). This seems like in the long run, we might end up with different env variables for all server endpoints which isn't ideal.

This just stores the server env variable, and let the client code add the other parts of the endpoint URL/route.

I figured this was a simple fix and felt like there's no need to create an issue for it, but will create it if there's a need for that.